### PR TITLE
use git to find the root of the git repo

### DIFF
--- a/lib/codacy/git.rb
+++ b/lib/codacy/git.rb
@@ -18,7 +18,7 @@ module Codacy
     end
 
     def self.git_dir
-      return Dir.pwd
+      return `git rev-parse --show-toplevel`
     end
 
     def self.git(command)


### PR DESCRIPTION
Hi there,

at Swrve out repository layout is as follows:

    /swrve
      /rails
        /spec
      /java
      /python

as such, when running our rspec tests, we have all gotten into the habbit of running

`cd rails && bundle exec rspec`

Unfortunately this means the Codacy ruby plugin will look for the `.git` file in the `/swrve/rails` dir. This pull request should remedy that.
