### PR TITLE
Allow Simplecov to be updated to version 0.11.x

### DIFF
--- a/codacy-coverage.gemspec
+++ b/codacy-coverage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_dependency 'simplecov', '~> 0.10.0'
+  gem.add_dependency 'simplecov', '>= 0.10.0'
   gem.add_dependency 'rest-client', '~> 1.8'
 
   gem.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Current Stable [Simplecov](https://github.com/colszowka/simplecov/tree/v0.11.1) Version is 0.11.1

```
Resolving dependencies.....
Bundler could not find compatible versions for gem "simplecov":
  In Gemfile:
    simplecov (>= 0.11.1)

    codacy-coverage was resolved to 0.0.1, which depends on
      simplecov (~> 0.10.0)
```