### PR TITLE
Update codacy-reporter to ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'rake', '>= 10.4'
-gem 'rspec', '>= 3.2'
+ruby "1.9.3"
+ 
+gem 'rake', :platforms => 'ruby_19'
+gem 'rspec', :platforms => 'ruby_19'
 gem 'simplecov', :require => false
-gem 'rest-client'

--- a/codacy-coverage.gemspec
+++ b/codacy-coverage.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency 'simplecov', '>= 0.10.0'
-  gem.add_dependency 'rest-client', '~> 1.8'
 
   gem.add_development_dependency 'bundler', '~> 1.7'
 end


### PR DESCRIPTION
Breaks compatibility with ruby < 1.9, and no longer depends on rest-client