### PR TITLE
Add Heroku CI variable for git commit SHA

### DIFF
--- a/lib/codacy/git.rb
+++ b/lib/codacy/git.rb
@@ -8,6 +8,7 @@ module Codacy
           ENV['CIRCLE_SHA1'] ||
           ENV['CI_COMMIT_ID'] ||
           ENV['WERCKER_GIT_COMMIT'] ||
+          ENV['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
           git_commit
 
       commit


### PR DESCRIPTION
Needs a similar approach to other CI services, as Heroku CI doesn't initialise a git repository on it's CI platform.

https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key