### PR TITLE
feature: Add google cloud build commit SHA

### DIFF
--- a/lib/codacy/git.rb
+++ b/lib/codacy/git.rb
@@ -10,6 +10,7 @@ module Codacy
           ENV['WERCKER_GIT_COMMIT'] ||
           ENV['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
           ENV['CI_COMMIT_SHA'] ||
+          ENV['COMMIT_SHA'] || # Google Cloud Build
           git_commit
 
       commit


### PR DESCRIPTION
https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_default_substitutions